### PR TITLE
✨ MAT-14: ingredient inventory CRUD (pantry page)

### DIFF
--- a/app/auth/error/page.tsx
+++ b/app/auth/error/page.tsx
@@ -1,24 +1,36 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Suspense } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
-export default async function Page({ searchParams }: { searchParams: Promise<{ error: string }> }) {
+async function ErrorContent({ searchParams }: { searchParams: Promise<{ error: string }> }) {
   const params = await searchParams
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-2xl">Sorry, something went wrong.</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {params?.error ? (
+          <p className="text-muted-foreground text-sm">Code error: {params.error}</p>
+        ) : (
+          <p className="text-muted-foreground text-sm">An unspecified error occurred.</p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
 
+export default function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ error: string }>
+}) {
   return (
     <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
       <div className="w-full max-w-sm">
         <div className="flex flex-col gap-6">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-2xl">Sorry, something went wrong.</CardTitle>
-            </CardHeader>
-            <CardContent>
-              {params?.error ? (
-                <p className="text-sm text-muted-foreground">Code error: {params.error}</p>
-              ) : (
-                <p className="text-sm text-muted-foreground">An unspecified error occurred.</p>
-              )}
-            </CardContent>
-          </Card>
+          <Suspense fallback={<Card><CardContent className="pt-6">Loading…</CardContent></Card>}>
+            <ErrorContent searchParams={searchParams} />
+          </Suspense>
         </div>
       </div>
     </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Bebas_Neue, Nunito } from "next/font/google";
 import { ThemeProvider } from "next-themes";
 import { Suspense } from "react";
 import { SiteHeader } from "@/components/site-header";
+import { QueryProvider } from "@/components/query-provider";
 import "./globals.css";
 
 const defaultUrl = process.env.VERCEL_URL
@@ -42,10 +43,12 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <Suspense>
-            <SiteHeader />
-          </Suspense>
-          {children}
+          <QueryProvider>
+            <Suspense>
+              <SiteHeader />
+            </Suspense>
+            {children}
+          </QueryProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/app/protected/ingredients/page.tsx
+++ b/app/protected/ingredients/page.tsx
@@ -1,0 +1,51 @@
+import { Suspense } from "react"
+import { redirect } from "next/navigation"
+import { createClient } from "@/lib/supabase/server"
+import { getIngredients } from "@/lib/actions/ingredients"
+import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query"
+import { IngredientList } from "@/components/ingredients/ingredient-list"
+import { AddIngredientDialog } from "@/components/ingredients/add-ingredient-dialog"
+
+export const metadata = { title: "My Pantry — ORB" }
+
+async function PantryContent() {
+  const supabase = await createClient()
+  const { data, error } = await supabase.auth.getClaims()
+  if (error || !data?.claims) redirect("/auth/login")
+
+  const qc = new QueryClient()
+  await qc.prefetchQuery({ queryKey: ["ingredients"], queryFn: getIngredients })
+
+  return (
+    <HydrationBoundary state={dehydrate(qc)}>
+      <IngredientList />
+    </HydrationBoundary>
+  )
+}
+
+export default function IngredientsPage() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-heading text-3xl">My Pantry</h1>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Track what you have at home
+          </p>
+        </div>
+        <AddIngredientDialog />
+      </div>
+      <Suspense
+        fallback={
+          <div className="space-y-2">
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="bg-muted h-10 animate-pulse rounded-md" />
+            ))}
+          </div>
+        }
+      >
+        <PantryContent />
+      </Suspense>
+    </div>
+  )
+}

--- a/app/protected/ingredients/page.tsx
+++ b/app/protected/ingredients/page.tsx
@@ -1,6 +1,4 @@
 import { Suspense } from "react"
-import { redirect } from "next/navigation"
-import { createClient } from "@/lib/supabase/server"
 import { getIngredients } from "@/lib/actions/ingredients"
 import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query"
 import { IngredientList } from "@/components/ingredients/ingredient-list"
@@ -9,10 +7,6 @@ import { AddIngredientDialog } from "@/components/ingredients/add-ingredient-dia
 export const metadata = { title: "My Pantry — ORB" }
 
 async function PantryContent() {
-  const supabase = await createClient()
-  const { data, error } = await supabase.auth.getClaims()
-  if (error || !data?.claims) redirect("/auth/login")
-
   const qc = new QueryClient()
   await qc.prefetchQuery({ queryKey: ["ingredients"], queryFn: getIngredients })
 

--- a/components/ingredients/add-ingredient-dialog.tsx
+++ b/components/ingredients/add-ingredient-dialog.tsx
@@ -1,0 +1,206 @@
+"use client"
+
+import { useState } from "react"
+import { PlusIcon } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useAddIngredient } from "@/lib/hooks/use-ingredients"
+import type { IngredientCategory, IngredientInput, IngredientUnit } from "@/lib/types"
+
+const UNITS: IngredientUnit[] = [
+  "unit", "g", "kg", "mg", "ml", "l", "cup", "tbsp", "tsp",
+  "oz", "lb", "pt", "qt", "pinch", "handful",
+]
+
+const CATEGORIES: { value: IngredientCategory; label: string }[] = [
+  { value: "pantry", label: "Pantry" },
+  { value: "fridge", label: "Fridge" },
+  { value: "freezer", label: "Freezer" },
+  { value: "other", label: "Other" },
+]
+
+const COMMON_INGREDIENTS = [
+  "Eggs", "Milk", "Butter", "Flour", "Sugar", "Salt", "Olive oil",
+  "Garlic", "Onion", "Tomato", "Chicken breast", "Ground beef", "Rice",
+  "Pasta", "Cheese", "Yogurt", "Lemon", "Carrot", "Potato", "Spinach",
+]
+
+const DEFAULT_FORM: IngredientInput = {
+  name: "",
+  quantity: 1,
+  unit: "unit",
+  category: "pantry",
+  expires_at: null,
+}
+
+interface Props {
+  defaultCategory?: IngredientCategory
+}
+
+export function AddIngredientDialog({ defaultCategory }: Props) {
+  const [open, setOpen] = useState(false)
+  const [form, setForm] = useState<IngredientInput>({
+    ...DEFAULT_FORM,
+    category: defaultCategory ?? "pantry",
+  })
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  const { mutate, isPending } = useAddIngredient()
+
+  function validate(): boolean {
+    const next: Record<string, string> = {}
+    if (!form.name.trim()) next.name = "Name is required"
+    if (!form.quantity || form.quantity <= 0) next.quantity = "Must be > 0"
+    setErrors(next)
+    return Object.keys(next).length === 0
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!validate()) return
+    mutate(form, {
+      onSuccess: () => {
+        setOpen(false)
+        setForm({ ...DEFAULT_FORM, category: defaultCategory ?? "pantry" })
+        setErrors({})
+      },
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm">
+          <PlusIcon />
+          Add ingredient
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Add ingredient</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="grid gap-4">
+          <div className="grid gap-1.5">
+            <Label htmlFor="name">Name</Label>
+            <Input
+              id="name"
+              list="common-ingredients"
+              value={form.name}
+              onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+              placeholder="e.g. Eggs"
+              aria-invalid={!!errors.name}
+              autoComplete="off"
+            />
+            <datalist id="common-ingredients">
+              {COMMON_INGREDIENTS.map((n) => (
+                <option key={n} value={n} />
+              ))}
+            </datalist>
+            {errors.name && (
+              <p className="text-destructive text-xs">{errors.name}</p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="grid gap-1.5">
+              <Label htmlFor="quantity">Quantity</Label>
+              <Input
+                id="quantity"
+                type="number"
+                min={0.01}
+                step="any"
+                value={form.quantity}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, quantity: parseFloat(e.target.value) || 0 }))
+                }
+                aria-invalid={!!errors.quantity}
+              />
+              {errors.quantity && (
+                <p className="text-destructive text-xs">{errors.quantity}</p>
+              )}
+            </div>
+            <div className="grid gap-1.5">
+              <Label>Unit</Label>
+              <Select
+                value={form.unit}
+                onValueChange={(v) => setForm((f) => ({ ...f, unit: v as IngredientUnit }))}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {UNITS.map((u) => (
+                    <SelectItem key={u} value={u}>
+                      {u}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label>Category</Label>
+            <Select
+              value={form.category}
+              onValueChange={(v) =>
+                setForm((f) => ({ ...f, category: v as IngredientCategory }))
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CATEGORIES.map((c) => (
+                  <SelectItem key={c.value} value={c.value}>
+                    {c.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label htmlFor="expires_at">Expiry date (optional)</Label>
+            <Input
+              id="expires_at"
+              type="date"
+              value={form.expires_at ?? ""}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, expires_at: e.target.value || null }))
+              }
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? "Adding…" : "Add ingredient"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/ingredients/add-ingredient-dialog.tsx
+++ b/components/ingredients/add-ingredient-dialog.tsx
@@ -79,6 +79,7 @@ export function AddIngredientDialog({ defaultCategory }: Props) {
         setForm({ ...DEFAULT_FORM, category: defaultCategory ?? "pantry" })
         setErrors({})
       },
+      onError: (e) => setErrors({ form: e.message }),
     })
   }
 
@@ -187,6 +188,10 @@ export function AddIngredientDialog({ defaultCategory }: Props) {
               }
             />
           </div>
+
+          {errors.form && (
+            <p className="text-destructive text-xs">{errors.form}</p>
+          )}
 
           <DialogFooter>
             <Button

--- a/components/ingredients/add-ingredient-dialog.tsx
+++ b/components/ingredients/add-ingredient-dialog.tsx
@@ -125,9 +125,10 @@ export function AddIngredientDialog({ defaultCategory }: Props) {
                 min={0.01}
                 step="any"
                 value={form.quantity}
-                onChange={(e) =>
-                  setForm((f) => ({ ...f, quantity: parseFloat(e.target.value) || 0 }))
-                }
+                onChange={(e) => {
+                  const val = parseFloat(e.target.value)
+                  setForm((f) => ({ ...f, quantity: isNaN(val) ? f.quantity : val }))
+                }}
                 aria-invalid={!!errors.quantity}
               />
               {errors.quantity && (

--- a/components/ingredients/ingredient-card.tsx
+++ b/components/ingredients/ingredient-card.tsx
@@ -33,7 +33,7 @@ const UNITS: IngredientUnit[] = [
 
 function formatExpiry(iso: string | null): string | null {
   if (!iso) return null
-  const [y, m, day] = iso.split("-").map(Number)
+  const [y, m, day] = iso.slice(0, 10).split("-").map(Number)
   const d = new Date(y, m - 1, day)
   const now = new Date()
   now.setHours(0, 0, 0, 0)
@@ -53,6 +53,7 @@ export function IngredientCard({ item }: Props) {
   const [name, setName] = useState(item.name)
   const [quantity, setQuantity] = useState(String(item.quantity))
   const [unit, setUnit] = useState<IngredientUnit>(item.unit)
+  const [expiresAt, setExpiresAt] = useState(item.expires_at?.slice(0, 10) ?? "")
   const [error, setError] = useState("")
 
   const { mutate: update, isPending: saving } = useUpdateIngredient()
@@ -62,6 +63,7 @@ export function IngredientCard({ item }: Props) {
     setName(item.name)
     setQuantity(String(item.quantity))
     setUnit(item.unit)
+    setExpiresAt(item.expires_at?.slice(0, 10) ?? "")
     setError("")
     setEditing(true)
   }
@@ -77,7 +79,7 @@ export function IngredientCard({ item }: Props) {
     if (!trimmedName) { setError("Name required"); return }
     if (isNaN(qty) || qty <= 0) { setError("Quantity must be > 0"); return }
     update(
-      { id: item.id, input: { name: trimmedName, quantity: qty, unit } },
+      { id: item.id, input: { name: trimmedName, quantity: qty, unit, expires_at: expiresAt || null } },
       { onSuccess: () => setEditing(false), onError: (e) => setError(e.message) },
     )
   }
@@ -116,6 +118,12 @@ export function IngredientCard({ item }: Props) {
             ))}
           </SelectContent>
         </Select>
+        <Input
+          className="h-7 w-32 text-sm"
+          type="date"
+          value={expiresAt}
+          onChange={(e) => setExpiresAt(e.target.value)}
+        />
         {error && <p className="text-destructive text-xs">{error}</p>}
         <Button size="icon-sm" variant="ghost" onClick={saveEdit} disabled={saving}>
           <CheckIcon />

--- a/components/ingredients/ingredient-card.tsx
+++ b/components/ingredients/ingredient-card.tsx
@@ -1,0 +1,176 @@
+"use client"
+
+import { useState } from "react"
+import { PencilIcon, Trash2Icon, CheckIcon, XIcon } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useDeleteIngredient, useUpdateIngredient } from "@/lib/hooks/use-ingredients"
+import type { IngredientUnit, PantryIngredient } from "@/lib/types"
+
+const UNITS: IngredientUnit[] = [
+  "unit", "g", "kg", "mg", "ml", "l", "cup", "tbsp", "tsp",
+  "oz", "lb", "pt", "qt", "pinch", "handful",
+]
+
+function formatExpiry(iso: string | null): string | null {
+  if (!iso) return null
+  const d = new Date(iso)
+  const now = new Date()
+  const diff = Math.ceil((d.getTime() - now.getTime()) / 86_400_000)
+  if (diff < 0) return "Expired"
+  if (diff === 0) return "Expires today"
+  if (diff <= 7) return `Expires in ${diff}d`
+  return `Exp: ${d.toLocaleDateString()}`
+}
+
+interface Props {
+  item: PantryIngredient
+}
+
+export function IngredientCard({ item }: Props) {
+  const [editing, setEditing] = useState(false)
+  const [name, setName] = useState(item.name)
+  const [quantity, setQuantity] = useState(String(item.quantity))
+  const [unit, setUnit] = useState<IngredientUnit>(item.unit)
+  const [error, setError] = useState("")
+
+  const { mutate: update, isPending: saving } = useUpdateIngredient()
+  const { mutate: del, isPending: deleting } = useDeleteIngredient()
+
+  function startEdit() {
+    setName(item.name)
+    setQuantity(String(item.quantity))
+    setUnit(item.unit)
+    setError("")
+    setEditing(true)
+  }
+
+  function cancelEdit() {
+    setEditing(false)
+    setError("")
+  }
+
+  function saveEdit() {
+    const trimmedName = name.trim()
+    const qty = parseFloat(quantity)
+    if (!trimmedName) { setError("Name required"); return }
+    if (!qty || qty <= 0) { setError("Quantity must be > 0"); return }
+    update(
+      { id: item.id, input: { name: trimmedName, quantity: qty, unit } },
+      { onSuccess: () => setEditing(false) },
+    )
+  }
+
+  const expiry = formatExpiry(item.expires_at)
+  const isExpired = expiry === "Expired"
+
+  if (editing) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border p-2">
+        <Input
+          className="h-7 flex-1 text-sm"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") saveEdit()
+            if (e.key === "Escape") cancelEdit()
+          }}
+          autoFocus
+        />
+        <Input
+          className="h-7 w-20 text-sm"
+          type="number"
+          min={0.01}
+          step="any"
+          value={quantity}
+          onChange={(e) => setQuantity(e.target.value)}
+        />
+        <Select value={unit} onValueChange={(v) => setUnit(v as IngredientUnit)}>
+          <SelectTrigger className="h-7 w-20 text-sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {UNITS.map((u) => (
+              <SelectItem key={u} value={u}>{u}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {error && <p className="text-destructive text-xs">{error}</p>}
+        <Button size="icon-sm" variant="ghost" onClick={saveEdit} disabled={saving}>
+          <CheckIcon />
+        </Button>
+        <Button size="icon-sm" variant="ghost" onClick={cancelEdit}>
+          <XIcon />
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-2 rounded-md border px-3 py-2">
+      <span className="flex-1 text-sm font-medium">{item.name}</span>
+      <Badge variant="secondary" className="text-xs tabular-nums">
+        {item.quantity} {item.unit}
+      </Badge>
+      {expiry && (
+        <span
+          className={`text-xs ${isExpired ? "text-destructive" : "text-muted-foreground"}`}
+        >
+          {expiry}
+        </span>
+      )}
+      <Button size="icon-sm" variant="ghost" onClick={startEdit} aria-label="Edit">
+        <PencilIcon />
+      </Button>
+      <AlertDialog>
+        <AlertDialogTrigger asChild>
+          <Button
+            size="icon-sm"
+            variant="ghost"
+            className="text-destructive hover:text-destructive"
+            aria-label="Delete"
+            disabled={deleting}
+          >
+            <Trash2Icon />
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete "{item.name}"?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently remove this ingredient from your pantry.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-white hover:bg-destructive/90"
+              onClick={() => del(item.id)}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/components/ingredients/ingredient-card.tsx
+++ b/components/ingredients/ingredient-card.tsx
@@ -75,10 +75,10 @@ export function IngredientCard({ item }: Props) {
     const trimmedName = name.trim()
     const qty = parseFloat(quantity)
     if (!trimmedName) { setError("Name required"); return }
-    if (!qty || qty <= 0) { setError("Quantity must be > 0"); return }
+    if (isNaN(qty) || qty <= 0) { setError("Quantity must be > 0"); return }
     update(
       { id: item.id, input: { name: trimmedName, quantity: qty, unit } },
-      { onSuccess: () => setEditing(false) },
+      { onSuccess: () => setEditing(false), onError: (e) => setError(e.message) },
     )
   }
 

--- a/components/ingredients/ingredient-card.tsx
+++ b/components/ingredients/ingredient-card.tsx
@@ -33,8 +33,10 @@ const UNITS: IngredientUnit[] = [
 
 function formatExpiry(iso: string | null): string | null {
   if (!iso) return null
-  const d = new Date(iso)
+  const [y, m, day] = iso.split("-").map(Number)
+  const d = new Date(y, m - 1, day)
   const now = new Date()
+  now.setHours(0, 0, 0, 0)
   const diff = Math.ceil((d.getTime() - now.getTime()) / 86_400_000)
   if (diff < 0) return "Expired"
   if (diff === 0) return "Expires today"

--- a/components/ingredients/ingredient-list.tsx
+++ b/components/ingredients/ingredient-list.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { useIngredients } from "@/lib/hooks/use-ingredients"
+import { IngredientCard } from "./ingredient-card"
+import { AddIngredientDialog } from "./add-ingredient-dialog"
+import type { IngredientCategory, PantryIngredient } from "@/lib/types"
+
+const SECTION_ORDER: IngredientCategory[] = ["pantry", "fridge", "freezer", "other"]
+const SECTION_LABELS: Record<IngredientCategory, string> = {
+  pantry: "Pantry",
+  fridge: "Fridge",
+  freezer: "Freezer",
+  other: "Other",
+}
+
+export function IngredientList() {
+  const { data, isLoading, isError } = useIngredients()
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="bg-muted h-10 animate-pulse rounded-md" />
+        ))}
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <p className="text-destructive text-sm">
+        Failed to load ingredients. Please refresh.
+      </p>
+    )
+  }
+
+  const grouped = (data ?? []).reduce<Record<IngredientCategory, PantryIngredient[]>>(
+    (acc, item) => {
+      const cat = item.category as IngredientCategory
+      if (!acc[cat]) acc[cat] = []
+      acc[cat].push(item)
+      return acc
+    },
+    { pantry: [], fridge: [], freezer: [], other: [] },
+  )
+
+  const nonEmptySections = SECTION_ORDER.filter((cat) => grouped[cat].length > 0)
+
+  if (nonEmptySections.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-16 text-center">
+        <p className="text-muted-foreground text-sm">
+          Your pantry is empty. Add your first ingredient to get started.
+        </p>
+        <AddIngredientDialog />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-8">
+      {nonEmptySections.map((cat) => (
+        <section key={cat}>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              {SECTION_LABELS[cat]}
+              <span className="ml-2 text-xs font-normal">
+                ({grouped[cat].length})
+              </span>
+            </h2>
+            <AddIngredientDialog defaultCategory={cat} />
+          </div>
+          <div className="space-y-2">
+            {grouped[cat].map((item) => (
+              <IngredientCard key={item.id} item={item} />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -31,7 +31,7 @@ export function MobileNav() {
         </SheetHeader>
         <nav className="flex flex-col gap-4 mt-8">
           <Link
-            href="/ingredients"
+            href="/protected/ingredients"
             className="text-lg font-medium hover:text-primary transition-colors"
             onClick={() => setOpen(false)}
           >

--- a/components/query-provider.tsx
+++ b/components/query-provider.tsx
@@ -1,0 +1,9 @@
+"use client"
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { useState } from "react"
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [client] = useState(() => new QueryClient())
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -25,7 +25,7 @@ export async function SiteHeader() {
         </Link>
 
         <nav className="hidden md:flex items-center gap-6 text-sm font-medium">
-          <Link href="/ingredients" className="hover:text-primary transition-colors">
+          <Link href="/protected/ingredients" className="hover:text-primary transition-colors">
             My Ingredients
           </Link>
           <Link href="/saved" className="hover:text-primary transition-colors">

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+const DialogTrigger = DialogPrimitive.Trigger
+const DialogPortal = DialogPrimitive.Portal
+const DialogClose = DialogPrimitive.Close
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className,
+        )}
+        {...props}
+      >
+        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+          <XIcon />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+        {children}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,136 @@
+"use client"
+
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+const Select = SelectPrimitive.Root
+const SelectGroup = SelectPrimitive.Group
+const SelectValue = SelectPrimitive.Value
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-full items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "popper",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className,
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectPrimitive.ScrollUpButton className="flex cursor-default items-center justify-center py-1">
+          <ChevronUpIcon className="size-4" />
+        </SelectPrimitive.ScrollUpButton>
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectPrimitive.ScrollDownButton className="flex cursor-default items-center justify-center py-1">
+          <ChevronDownIcon className="size-4" />
+        </SelectPrimitive.ScrollDownButton>
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/lib/actions/ingredients.ts
+++ b/lib/actions/ingredients.ts
@@ -12,10 +12,11 @@ async function getAuthedClient() {
 }
 
 export async function getIngredients(): Promise<PantryIngredient[]> {
-  const { supabase } = await getAuthedClient()
+  const { supabase, userId } = await getAuthedClient()
   const { data, error } = await supabase
     .from("ingredients")
     .select("*")
+    .eq("user_id", userId)
     .order("name")
   if (error) throw new Error(error.message)
   return (data ?? []) as PantryIngredient[]
@@ -29,7 +30,14 @@ export async function addIngredient(input: IngredientInput): Promise<PantryIngre
 
   const { data, error } = await supabase
     .from("ingredients")
-    .insert({ ...input, name, user_id: userId })
+    .insert({
+      name,
+      quantity: input.quantity,
+      unit: input.unit,
+      category: input.category,
+      expires_at: input.expires_at ?? null,
+      user_id: userId,
+    })
     .select()
     .single()
   if (error) throw new Error(error.message)
@@ -41,15 +49,19 @@ export async function updateIngredient(
   input: Partial<IngredientInput>,
 ): Promise<PantryIngredient> {
   const { supabase, userId } = await getAuthedClient()
-  const patch: Partial<IngredientInput> = { ...input }
-  if (patch.name !== undefined) {
-    const name = patch.name.trim()
+  const patch: Partial<IngredientInput> = {}
+  if (input.name !== undefined) {
+    const name = input.name.trim()
     if (!name) throw new Error("Name is required")
     patch.name = name
   }
-  if (patch.quantity !== undefined && patch.quantity <= 0) {
-    throw new Error("Quantity must be positive")
+  if (input.quantity !== undefined) {
+    if (input.quantity <= 0) throw new Error("Quantity must be positive")
+    patch.quantity = input.quantity
   }
+  if (input.unit !== undefined) patch.unit = input.unit
+  if (input.category !== undefined) patch.category = input.category
+  if (input.expires_at !== undefined) patch.expires_at = input.expires_at
 
   const { data, error } = await supabase
     .from("ingredients")

--- a/lib/actions/ingredients.ts
+++ b/lib/actions/ingredients.ts
@@ -1,0 +1,73 @@
+"use server"
+
+import { redirect } from "next/navigation"
+import { createClient } from "@/lib/supabase/server"
+import type { PantryIngredient, IngredientInput } from "@/lib/types"
+
+async function getAuthedClient() {
+  const supabase = await createClient()
+  const { data, error } = await supabase.auth.getClaims()
+  if (error || !data?.claims) redirect("/auth/login")
+  return { supabase, userId: data.claims.sub as string }
+}
+
+export async function getIngredients(): Promise<PantryIngredient[]> {
+  const { supabase } = await getAuthedClient()
+  const { data, error } = await supabase
+    .from("ingredients")
+    .select("*")
+    .order("name")
+  if (error) throw new Error(error.message)
+  return (data ?? []) as PantryIngredient[]
+}
+
+export async function addIngredient(input: IngredientInput): Promise<PantryIngredient> {
+  const { supabase, userId } = await getAuthedClient()
+  const name = input.name.trim()
+  if (!name) throw new Error("Name is required")
+  if (input.quantity <= 0) throw new Error("Quantity must be positive")
+
+  const { data, error } = await supabase
+    .from("ingredients")
+    .insert({ ...input, name, user_id: userId })
+    .select()
+    .single()
+  if (error) throw new Error(error.message)
+  return data as PantryIngredient
+}
+
+export async function updateIngredient(
+  id: string,
+  input: Partial<IngredientInput>,
+): Promise<PantryIngredient> {
+  const { supabase, userId } = await getAuthedClient()
+  const patch: Partial<IngredientInput> = { ...input }
+  if (patch.name !== undefined) {
+    const name = patch.name.trim()
+    if (!name) throw new Error("Name is required")
+    patch.name = name
+  }
+  if (patch.quantity !== undefined && patch.quantity <= 0) {
+    throw new Error("Quantity must be positive")
+  }
+
+  const { data, error } = await supabase
+    .from("ingredients")
+    .update(patch)
+    .eq("id", id)
+    .eq("user_id", userId)
+    .select()
+    .single()
+  if (error) throw new Error(error.message)
+  return data as PantryIngredient
+}
+
+export async function deleteIngredient(id: string): Promise<void> {
+  const { supabase, userId } = await getAuthedClient()
+  const { error } = await supabase
+    .from("ingredients")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", userId)
+  if (error) throw new Error(error.message)
+}

--- a/lib/hooks/use-ingredients.ts
+++ b/lib/hooks/use-ingredients.ts
@@ -1,0 +1,56 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  addIngredient,
+  deleteIngredient,
+  getIngredients,
+  updateIngredient,
+} from "@/lib/actions/ingredients"
+import type { IngredientInput, PantryIngredient } from "@/lib/types"
+
+const QUERY_KEY = ["ingredients"] as const
+
+export function useIngredients() {
+  return useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: getIngredients,
+  })
+}
+
+export function useAddIngredient() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (input: IngredientInput) => addIngredient(input),
+    onSuccess: (item) => {
+      qc.setQueryData<PantryIngredient[]>(QUERY_KEY, (prev = []) =>
+        [...prev, item].sort((a, b) => a.name.localeCompare(b.name)),
+      )
+    },
+  })
+}
+
+export function useUpdateIngredient() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: Partial<IngredientInput> }) =>
+      updateIngredient(id, input),
+    onSuccess: (updated) => {
+      qc.setQueryData<PantryIngredient[]>(QUERY_KEY, (prev = []) =>
+        prev.map((i) => (i.id === updated.id ? updated : i)),
+      )
+    },
+  })
+}
+
+export function useDeleteIngredient() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => deleteIngredient(id),
+    onSuccess: (_, id) => {
+      qc.setQueryData<PantryIngredient[]>(QUERY_KEY, (prev = []) =>
+        prev.filter((i) => i.id !== id),
+      )
+    },
+  })
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -6,6 +6,33 @@ export interface Ingredient {
   category?: string
 }
 
+export type IngredientUnit =
+  | "g" | "kg" | "mg" | "ml" | "l" | "cup" | "tbsp" | "tsp"
+  | "oz" | "lb" | "pt" | "qt" | "unit" | "pinch" | "handful"
+
+export type IngredientCategory = "pantry" | "fridge" | "freezer" | "other"
+
+export interface PantryIngredient {
+  id: string
+  user_id: string
+  name: string
+  quantity: number
+  unit: IngredientUnit
+  category: IngredientCategory
+  expires_at: string | null
+  notes: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface IngredientInput {
+  name: string
+  quantity: number
+  unit: IngredientUnit
+  category: IngredientCategory
+  expires_at?: string | null
+}
+
 export interface RecipeIngredient {
   id?: string
   recipe_id?: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,20 @@
 {
-  "name": "rio-de-janeiro",
+  "name": "denpasar",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.1",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.14",
         "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
         "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.84.0",
+        "@tanstack/react-query": "^5.99.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.511.0",
@@ -2045,6 +2049,32 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.99.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.2.tgz",
+      "integrity": "sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.99.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.2.tgz",
+      "integrity": "sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.99.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -8,12 +8,16 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.1",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.14",
     "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.84.0",
+    "@tanstack/react-query": "^5.99.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.511.0",


### PR DESCRIPTION
## Summary

- Adds a protected `/protected/ingredients` pantry page where users can create, read, update, and delete their ingredients, grouped by storage location (Pantry, Fridge, Freezer, Other)
- Introduces TanStack Query (`@tanstack/react-query`) for client-side state with optimistic cache updates after mutations, wired via a new `QueryProvider` in the root layout
- Adds Supabase server actions for all ingredient CRUD operations scoped to the authenticated user, plus new `PantryIngredient`, `IngredientInput`, `IngredientUnit`, and `IngredientCategory` types
- Adds three new Radix UI-backed shadcn components: `Dialog`, `AlertDialog`, and `Select`
- Refactors the auth error page to use `Suspense` to satisfy Next.js async `searchParams` requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)