### PR TITLE
✨ MAT-15: AuthNudge popover + inline integration

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,15 @@
+import { createClient } from "@/lib/supabase/server"
+import { hasEnvVars } from "@/lib/utils"
 import { RecipeSearch } from "@/components/recipes/recipe-search"
 
-export default function Home() {
+export default async function Home() {
+  let isLoggedIn = false
+  if (hasEnvVars) {
+    const supabase = await createClient()
+    const { data } = await supabase.auth.getClaims()
+    isLoggedIn = !!data?.claims?.email
+  }
+
   return (
     <main className="min-h-[calc(100vh-4rem)] flex flex-col items-center px-4 pt-16 pb-16">
       <div className="w-full max-w-5xl flex flex-col items-center gap-10">
@@ -13,7 +22,7 @@ export default function Home() {
           </p>
         </div>
 
-        <RecipeSearch />
+        <RecipeSearch isLoggedIn={isLoggedIn} />
       </div>
     </main>
   )

--- a/app/recipes/[id]/page.tsx
+++ b/app/recipes/[id]/page.tsx
@@ -1,4 +1,6 @@
 import { notFound } from "next/navigation"
+import { createClient } from "@/lib/supabase/server"
+import { hasEnvVars } from "@/lib/utils"
 import { getRecipeById } from "@/lib/actions/recipes"
 import { RecipeDetailView } from "@/components/recipes/recipe-detail"
 
@@ -12,5 +14,12 @@ export default async function RecipePage({ params }: RecipePageProps) {
 
   if (!recipe) notFound()
 
-  return <RecipeDetailView recipe={recipe} />
+  let isLoggedIn = false
+  if (hasEnvVars) {
+    const supabase = await createClient()
+    const { data } = await supabase.auth.getClaims()
+    isLoggedIn = !!data?.claims?.email
+  }
+
+  return <RecipeDetailView recipe={recipe} isLoggedIn={isLoggedIn} />
 }

--- a/components/auth-nudge.tsx
+++ b/components/auth-nudge.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { useState } from "react"
+import { createClient } from "@/lib/supabase/client"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Button } from "@/components/ui/button"
+
+interface AuthNudgeProps {
+  message: string
+  isLoggedIn: boolean
+  children: React.ReactElement<{ onClick?: React.MouseEventHandler }>
+}
+
+export function AuthNudge({ message, isLoggedIn, children }: AuthNudgeProps) {
+  const [open, setOpen] = useState(false)
+
+  if (isLoggedIn) return children
+
+  const handleSignIn = async () => {
+    const supabase = createClient()
+    await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: { redirectTo: `${window.location.origin}/auth/confirm` },
+    })
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent className="w-64 space-y-3" align="start">
+        <p className="text-sm text-muted-foreground">{message}</p>
+        <div className="flex flex-col gap-2">
+          <Button size="sm" onClick={handleSignIn} className="w-full">
+            Continue with Google
+          </Button>
+          <Button size="sm" variant="ghost" onClick={() => setOpen(false)} className="w-full">
+            Maybe later
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/components/auth-nudge.tsx
+++ b/components/auth-nudge.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { cloneElement, useState } from "react"
 import { createClient } from "@/lib/supabase/client"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Button } from "@/components/ui/button"
@@ -8,27 +8,34 @@ import { Button } from "@/components/ui/button"
 interface AuthNudgeProps {
   message: string
   isLoggedIn: boolean
-  children: React.ReactElement<{ onClick?: React.MouseEventHandler }>
+  children: React.ReactElement<{ onClick?: React.MouseEventHandler; disabled?: boolean }>
 }
 
 export function AuthNudge({ message, isLoggedIn, children }: AuthNudgeProps) {
   const [open, setOpen] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   if (isLoggedIn) return children
 
   const handleSignIn = async () => {
+    setError(null)
     const supabase = createClient()
-    await supabase.auth.signInWithOAuth({
+    const { error } = await supabase.auth.signInWithOAuth({
       provider: "google",
       options: { redirectTo: `${window.location.origin}/auth/confirm` },
     })
+    if (error) setError("Something went wrong. Please try again.")
   }
+
+  // Strip disabled so the popover trigger can receive click events
+  const trigger = cloneElement(children, { disabled: false })
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       <PopoverContent className="w-64 space-y-3" align="start">
         <p className="text-sm text-muted-foreground">{message}</p>
+        {error && <p className="text-xs text-destructive">{error}</p>}
         <div className="flex flex-col gap-2">
           <Button size="sm" onClick={handleSignIn} className="w-full">
             Continue with Google

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useState } from "react"
-import Link from "next/link"
 import { Menu } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
@@ -11,8 +10,13 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet"
+import { NavLinks } from "@/components/nav-links"
 
-export function MobileNav() {
+interface MobileNavProps {
+  isLoggedIn: boolean
+}
+
+export function MobileNav({ isLoggedIn }: MobileNavProps) {
   const [open, setOpen] = useState(false)
 
   return (
@@ -30,20 +34,11 @@ export function MobileNav() {
           </SheetTitle>
         </SheetHeader>
         <nav className="flex flex-col gap-4 mt-8">
-          <Link
-            href="/protected/ingredients"
-            className="text-lg font-medium hover:text-primary transition-colors"
+          <NavLinks
+            isLoggedIn={isLoggedIn}
+            className="text-lg font-medium hover:text-primary transition-colors text-left"
             onClick={() => setOpen(false)}
-          >
-            My Ingredients
-          </Link>
-          <Link
-            href="/saved"
-            className="text-lg font-medium hover:text-primary transition-colors"
-            onClick={() => setOpen(false)}
-          >
-            Saved
-          </Link>
+          />
         </nav>
       </SheetContent>
     </Sheet>

--- a/components/nav-links.tsx
+++ b/components/nav-links.tsx
@@ -4,7 +4,7 @@ import Link from "next/link"
 import { AuthNudge } from "@/components/auth-nudge"
 
 const NAV_ITEMS = [
-  { href: "/ingredients", label: "My Ingredients", message: "Sign in to track your pantry ingredients." },
+  { href: "/protected/ingredients", label: "My Ingredients", message: "Sign in to track your pantry ingredients." },
   { href: "/saved", label: "Saved", message: "Sign in to save recipes for later." },
 ]
 

--- a/components/nav-links.tsx
+++ b/components/nav-links.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import Link from "next/link"
+import { AuthNudge } from "@/components/auth-nudge"
+
+const NAV_ITEMS = [
+  { href: "/ingredients", label: "My Ingredients", message: "Sign in to track your pantry ingredients." },
+  { href: "/saved", label: "Saved", message: "Sign in to save recipes for later." },
+]
+
+interface NavLinksProps {
+  isLoggedIn: boolean
+  className?: string
+  onClick?: () => void
+}
+
+export function NavLinks({ isLoggedIn, className, onClick }: NavLinksProps) {
+  return (
+    <>
+      {NAV_ITEMS.map(({ href, label, message }) =>
+        isLoggedIn ? (
+          <Link key={href} href={href} className={className} onClick={onClick}>
+            {label}
+          </Link>
+        ) : (
+          <AuthNudge key={href} message={message} isLoggedIn={false}>
+            <button className={className}>{label}</button>
+          </AuthNudge>
+        )
+      )}
+    </>
+  )
+}

--- a/components/recipes/recipe-card.tsx
+++ b/components/recipes/recipe-card.tsx
@@ -2,13 +2,15 @@ import Link from "next/link"
 import Image from "next/image"
 import { Clock, Bookmark } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { AuthNudge } from "@/components/auth-nudge"
 import type { RecipeSearchResult } from "@/lib/types"
 
 interface RecipeCardProps {
   recipe: RecipeSearchResult
+  isLoggedIn: boolean
 }
 
-export function RecipeCard({ recipe }: RecipeCardProps) {
+export function RecipeCard({ recipe, isLoggedIn }: RecipeCardProps) {
   return (
     <div className="group relative flex flex-col rounded-xl border border-border bg-card overflow-hidden shadow-sm hover:shadow-md transition-shadow">
       <Link href={`/recipes/${recipe.id}`} className="flex flex-col flex-1">
@@ -48,16 +50,12 @@ export function RecipeCard({ recipe }: RecipeCardProps) {
       </Link>
 
       <div className="px-4 pb-4">
-        <Button
-          variant="outline"
-          size="sm"
-          className="w-full gap-1.5"
-          disabled
-          aria-label="Save recipe"
-        >
-          <Bookmark className="size-3.5" />
-          Save
-        </Button>
+        <AuthNudge message="Sign in to save recipes for later." isLoggedIn={isLoggedIn}>
+          <Button variant="outline" size="sm" className="w-full gap-1.5" aria-label="Save recipe">
+            <Bookmark className="size-3.5" />
+            Save
+          </Button>
+        </AuthNudge>
       </div>
     </div>
   )

--- a/components/recipes/recipe-detail.tsx
+++ b/components/recipes/recipe-detail.tsx
@@ -2,14 +2,16 @@ import Image from "next/image"
 import { Clock, ChefHat, Users, Timer, Bookmark, FlaskConical } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
+import { AuthNudge } from "@/components/auth-nudge"
 import { cn } from "@/lib/utils"
 import type { RecipeDetail } from "@/lib/types"
 
 interface RecipeDetailProps {
   recipe: RecipeDetail
+  isLoggedIn: boolean
 }
 
-export function RecipeDetailView({ recipe }: RecipeDetailProps) {
+export function RecipeDetailView({ recipe, isLoggedIn }: RecipeDetailProps) {
   const instructions = parseInstructions(recipe.instructions)
 
   return (
@@ -64,14 +66,18 @@ export function RecipeDetailView({ recipe }: RecipeDetailProps) {
 
       {/* Action buttons */}
       <div className="flex gap-3">
-        <Button variant="default" className="gap-2" disabled>
-          <Bookmark className="size-4" />
-          Save recipe
-        </Button>
-        <Button variant="outline" className="gap-2" disabled>
-          <FlaskConical className="size-4" />
-          Check what I have
-        </Button>
+        <AuthNudge message="Sign in to save recipes for later." isLoggedIn={isLoggedIn}>
+          <Button variant="default" className="gap-2">
+            <Bookmark className="size-4" />
+            Save recipe
+          </Button>
+        </AuthNudge>
+        <AuthNudge message="Sign in to check which ingredients you already have." isLoggedIn={isLoggedIn}>
+          <Button variant="outline" className="gap-2">
+            <FlaskConical className="size-4" />
+            Check what I have
+          </Button>
+        </AuthNudge>
       </div>
 
       {/* Ingredients */}

--- a/components/recipes/recipe-grid.tsx
+++ b/components/recipes/recipe-grid.tsx
@@ -3,15 +3,16 @@ import type { RecipeSearchResult } from "@/lib/types"
 
 interface RecipeGridProps {
   recipes: RecipeSearchResult[]
+  isLoggedIn: boolean
 }
 
-export function RecipeGrid({ recipes }: RecipeGridProps) {
+export function RecipeGrid({ recipes, isLoggedIn }: RecipeGridProps) {
   if (recipes.length === 0) return null
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 w-full">
       {recipes.map((recipe) => (
-        <RecipeCard key={recipe.id} recipe={recipe} />
+        <RecipeCard key={recipe.id} recipe={recipe} isLoggedIn={isLoggedIn} />
       ))}
     </div>
   )

--- a/components/recipes/recipe-search.tsx
+++ b/components/recipes/recipe-search.tsx
@@ -9,7 +9,11 @@ import type { RecipeSearchResult, SearchSuggestion } from "@/lib/types"
 
 const MIN_QUERY_LENGTH = 2
 
-export function RecipeSearch() {
+interface RecipeSearchProps {
+  isLoggedIn: boolean
+}
+
+export function RecipeSearch({ isLoggedIn }: RecipeSearchProps) {
   const [query, setQuery] = useState("")
   const [suggestions, setSuggestions] = useState<SearchSuggestion[]>([])
   const [activeIndex, setActiveIndex] = useState(-1)
@@ -168,7 +172,7 @@ export function RecipeSearch() {
       )}
 
       {!isPending && results.length > 0 && (
-        <RecipeGrid recipes={results} />
+        <RecipeGrid recipes={results} isLoggedIn={isLoggedIn} />
       )}
     </div>
   )

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server"
 import { ThemeSwitcher } from "@/components/theme-switcher"
 import { MobileNav } from "@/components/mobile-nav"
 import { UserAvatarDropdown } from "@/components/user-avatar-dropdown"
+import { NavLinks } from "@/components/nav-links"
 import { Button } from "@/components/ui/button"
 import { hasEnvVars } from "@/lib/utils"
 
@@ -13,6 +14,8 @@ export async function SiteHeader() {
     const { data } = await supabase.auth.getClaims()
     user = data?.claims
   }
+
+  const isLoggedIn = !!user?.email
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-b-foreground/10 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -25,24 +28,19 @@ export async function SiteHeader() {
         </Link>
 
         <nav className="hidden md:flex items-center gap-6 text-sm font-medium">
-          <Link href="/protected/ingredients" className="hover:text-primary transition-colors">
-            My Ingredients
-          </Link>
-          <Link href="/saved" className="hover:text-primary transition-colors">
-            Saved
-          </Link>
+          <NavLinks isLoggedIn={isLoggedIn} className="hover:text-primary transition-colors" />
         </nav>
 
         <div className="flex items-center gap-2">
           <ThemeSwitcher />
-          {user?.email ? (
+          {isLoggedIn && user?.email ? (
             <UserAvatarDropdown email={user.email} />
           ) : (
             <Button asChild size="sm" variant="outline">
               <Link href="/auth/login">Log in</Link>
             </Button>
           )}
-          <MobileNav />
+          <MobileNav isLoggedIn={isLoggedIn} />
         </div>
       </div>
     </header>

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+}

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -52,6 +52,7 @@ export async function updateSession(request: NextRequest) {
     !user &&
     !request.nextUrl.pathname.startsWith("/login") &&
     !request.nextUrl.pathname.startsWith("/auth") &&
+    !request.nextUrl.pathname.startsWith("/recipes") &&
     !request.nextUrl.pathname.startsWith("/api/admin")
   ) {
     // no user, potentially respond by redirecting the user to the login page

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "denpasar",
+  "name": "orb",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -14,7 +14,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.84.0",
-        "@tanstack/react-query": "^5.99.2",
+        "@tanstack/react-query": "^5.100.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.511.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.84.0",
-    "@tanstack/react-query": "^5.99.2",
+    "@tanstack/react-query": "^5.100.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.511.0",


### PR DESCRIPTION
Closes https://linear.app/mathewsfranco/issue/MAT-15/11-authnudge-popover-inline-integration

## Summary

- Adds `components/auth-nudge.tsx`: reusable shadcn `Popover` wrapper that intercepts clicks for anonymous users, shows a contextual message + **Continue with Google** CTA and **Maybe later** dismiss. Logged-in users: pass-through no-op.
- Adds `components/nav-links.tsx`: auth-aware nav items — renders `<Link>` for authenticated users, `<button>` + `AuthNudge` for anonymous users.
- Wires `AuthNudge` into:
  - Save button on `recipe-card.tsx`
  - Save recipe + Check what I have buttons on `recipe-detail.tsx`
  - My Ingredients + Saved nav links in `site-header.tsx` and `mobile-nav.tsx`
- `isLoggedIn` resolved server-side via `supabase.auth.getClaims()` on `app/page.tsx` and `app/recipes/[id]/page.tsx`, passed down as a prop — anonymous users on `/` and `/recipes/[id]` are never redirected.
- OAuth error surfaced inline in the popover (no silent failure).
- `cloneElement` strips `disabled` from the trigger so the popover opens even if a caller passes a disabled button.

## Test plan

- [ ] Anonymous: click Save on a recipe card → nudge popover appears with message + CTA
- [ ] Anonymous: click Save recipe / Check what I have on detail page → nudge appears
- [ ] Anonymous: click My Ingredients / Saved in header → nudge appears, no redirect
- [ ] Anonymous: click Maybe later → popover dismisses, user stays on page
- [ ] Anonymous: click Continue with Google → OAuth flow initiates
- [ ] Logged-in: all buttons and nav links work normally, no popover
- [ ] Mobile: nudge works via mobile nav sheet
- [ ] Simulate OAuth failure: error message renders inside popover

🤖 Generated with [Claude Code](https://claude.com/claude-code)